### PR TITLE
Fix to generate keys in PEM format for ProFTPd

### DIFF
--- a/lib/Virtualmin/Config/Plugin/ProFTPd.pm
+++ b/lib/Virtualmin/Config/Plugin/ProFTPd.pm
@@ -92,11 +92,11 @@ sub actions {
     # Generate ssh key pairs
     if (!-f '/etc/proftpd/ssh_host_ecdsa_key') {
       $self->logsystem(
-        "ssh-keygen -f /etc/proftpd/ssh_host_ecdsa_key -t ecdsa -N ''");
+        "ssh-keygen -f /etc/proftpd/ssh_host_ecdsa_key -t ecdsa -N '' -m PEM");
     }
     if (!-f '/etc/proftpd/ssh_host_rsa_key') {
       $self->logsystem(
-        "ssh-keygen -f /etc/proftpd/ssh_host_rsa_key -t rsa -N ''");
+        "ssh-keygen -f /etc/proftpd/ssh_host_rsa_key -t rsa -N '' -m PEM");
     }
 
     my $vmconf = <<"EOF";


### PR DESCRIPTION
As explained [here](https://www.virtualmin.com/node/68613#comment-823497), _mod_sftp_ expects PEM format for now, while latest versions of `ssh-keygen` (distributed with Debian 10 and Fedora) declared it as "legacy", and require explicit declaration for PEM format to be generated.