### PR TITLE
Better to add this for now

### DIFF
--- a/lib/Virtualmin/Config/Plugin/ProFTPd.pm
+++ b/lib/Virtualmin/Config/Plugin/ProFTPd.pm
@@ -109,7 +109,7 @@ TLSEngine                     on
 TLSRequired                   off
 TLSRSACertificateFile         $certfile
 TLSRSACertificateKeyFile      $keyfile
-TLSOptions                    NoCertRequest
+TLSOptions                    NoCertRequest NoSessionReuseRequired
 TLSVerifyClient               off
 TLSLog                        /var/log/proftpd/tls.log
 <IfModule mod_tls_shmcache.c>


### PR DESCRIPTION
The latest ProFTPd server has a configuration setting that by default requires SSL/TLS sessions to be re-used, and this breaks many FTP clients, including FileZilla and other.