### PR TITLE
Revert "Don't touch resolve". Incomplete.

### DIFF
--- a/lib/Virtualmin/Config/Plugin/Net.pm
+++ b/lib/Virtualmin/Config/Plugin/Net.pm
@@ -43,6 +43,17 @@ sub actions {
         net::save_dns_config($dns);
       }
 
+      # Force 127.0.0.1 into name servers in resolv.conf
+      # XXX This shouldn't be necessary. There's some kind of bug in net::
+      my $resolvconf = '/etc/resolv.conf';
+      my $rlref      = read_file_lines($resolvconf);
+      if (indexof('nameserver 127.0.0.1'), @{$rlref} < 0) {
+        $log->info("Adding name server 127.0.0.1 to resolv.conf.");
+        unshift(@{$rlref}, 'nameserver 127.0.0.1');
+        unshift(@{$rlref}, '# Added by Virtualmin.');
+      }
+      flush_file_lines($resolvconf);
+
       # On Debian/Ubuntu, if there are extra interfaces files, we need
       # to update them, too.
       # Check for additional included config files.


### PR DESCRIPTION
This reverts commit fe968b6f33d57fccab4fd465ccef4c7791ccf2ec.

The right way to solve this is to skip Net.pm by default. All it does it update resolv.conf in a variety of ways. This commit only addresses one of them. So, the right thing is not to run it at all.