### PR TITLE
Add better way of handling configurations depending on the stack

### DIFF
--- a/lib/Virtualmin/Config.pm
+++ b/lib/Virtualmin/Config.pm
@@ -111,12 +111,16 @@ sub _gather_plugins {
 
   # If bundle specified, load it up.
   if ($self->{bundle}) {
+    # Get bundle
     my $pkg = "Virtualmin::Config::$self->{bundle}";
     load $pkg;
-    my $bundle = $pkg->new();
-
+    my $bundle = $pkg->new();    
+    # Get stack
+    my $pkg2 = "Virtualmin::Config::Stack";
+    load $pkg2;
+    my $stack = $pkg2->new();
     # Ask the bundle for a list of plugins
-    @plugins = $bundle->plugins();
+    @plugins = $bundle->plugins($stack);
   }
 
   # Check with the command arguments

--- a/lib/Virtualmin/Config/LAMP.pm
+++ b/lib/Virtualmin/Config/LAMP.pm
@@ -13,28 +13,8 @@ sub new {
 }
 
 sub plugins {
-
-  # Modern system with firewalld?
-  if (-x "/usr/bin/firewall-cmd" || -x "/bin/firewall-cmd") {
-    return [
-      "Webmin",       "Apache",            "Bind",
-      "Dovecot",      "AWStats",           "Postfix",
-      "MySQL",        "Firewalld",         "Procmail",
-      "ProFTPd",      "Quotas",            "SASL",
-      "Shells",       "Status",            "Upgrade",
-      "Usermin",      "Virtualmin",        "ClamAV",
-      "SpamAssassin", "Fail2banFirewalld", "Etckeeper"
-    ];
-  }
-  else {
-    return [
-      "Webmin",  "Apache",     "Bind",     "Dovecot",      "AWStats",
-      "Postfix", "MySQL",      "Firewall", "Procmail",     "ProFTPd",
-      "Quotas",  "SASL",       "Shells",   "Status",       "Upgrade",
-      "Usermin", "Virtualmin", "ClamAV",   "SpamAssassin", "Fail2ban",
-      "Etckeeper"
-    ];
-  }
+  my ($self, $stack) = @_;
+  return $stack->list('lamp', 1);
 }
 
 1;

--- a/lib/Virtualmin/Config/LAMP.pm
+++ b/lib/Virtualmin/Config/LAMP.pm
@@ -14,7 +14,7 @@ sub new {
 
 sub plugins {
   my ($self, $stack) = @_;
-  return $stack->list('lamp', 1);
+  return $stack->list('lamp', 'full');
 }
 
 1;

--- a/lib/Virtualmin/Config/LEMP.pm
+++ b/lib/Virtualmin/Config/LEMP.pm
@@ -14,7 +14,7 @@ sub new {
 
 sub plugins {
   my ($self, $stack) = @_;
-  return $stack->list('lemp', 1);
+  return $stack->list('lemp', 'full');
 }
 
 1;

--- a/lib/Virtualmin/Config/LEMP.pm
+++ b/lib/Virtualmin/Config/LEMP.pm
@@ -13,28 +13,8 @@ sub new {
 }
 
 sub plugins {
-
-  # Modern system with firewalld?
-  if (-x "/usr/bin/firewall-cmd" || -x "/bin/firewall-cmd") {
-    return [
-      "Webmin",       "Nginx",             "Bind",
-      "Dovecot",      "AWStats",           "Postfix",
-      "MySQL",        "Firewalld",         "Procmail",
-      "ProFTPd",      "Quotas",            "SASL",
-      "Shells",       "Status",            "Upgrade",
-      "Usermin",      "Virtualmin",        "ClamAV",
-      "SpamAssassin", "Fail2banFirewalld", "Etckeeper"
-    ];
-  }
-  else {
-    return [
-      "Webmin",  "Nginx",      "Bind",     "Dovecot",      "AWStats",
-      "Postfix", "MySQL",      "Firewall", "Procmail",     "ProFTPd",
-      "Quotas",  "SASL",       "Shells",   "Status",       "Upgrade",
-      "Usermin", "Virtualmin", "ClamAV",   "SpamAssassin", "Fail2ban",
-      "Etckeeper"
-    ];
-  }
+  my ($self, $stack) = @_;
+  return $stack->list('lemp', 1);
 }
 
 1;

--- a/lib/Virtualmin/Config/MiniLAMP.pm
+++ b/lib/Virtualmin/Config/MiniLAMP.pm
@@ -13,24 +13,8 @@ sub new {
 }
 
 sub plugins {
-
-  # Modern system with firewalld?
-  if (-x "/usr/bin/firewall-cmd" || -x "/bin/firewall-cmd") {
-    return [
-      "Webmin",    "Apache",   "Bind",    "Postfix",    "MySQL",
-      "Firewalld", "Procmail", "ProFTPd", "Quotas",     "Shells",
-      "Status",    "Upgrade",  "Usermin", "Virtualmin", "Dovecot",
-      "SASL",      "Etckeeper"
-    ];
-  }
-  else {
-    return [
-      "Webmin",   "Apache",   "Bind",    "Postfix",    "MySQL",
-      "Firewall", "Procmail", "ProFTPd", "Quotas",     "Shells",
-      "Status",   "Upgrade",  "Usermin", "Virtualmin", "Dovecot",
-      "SASL",     "Etckeeper"
-    ];
-  }
+  my ($self, $stack) = @_;
+  return $stack->list('lamp');
 }
 
 1;

--- a/lib/Virtualmin/Config/MiniLAMP.pm
+++ b/lib/Virtualmin/Config/MiniLAMP.pm
@@ -14,7 +14,7 @@ sub new {
 
 sub plugins {
   my ($self, $stack) = @_;
-  return $stack->list('lamp');
+  return $stack->list('lamp', 'mini');
 }
 
 1;

--- a/lib/Virtualmin/Config/MiniLEMP.pm
+++ b/lib/Virtualmin/Config/MiniLEMP.pm
@@ -13,24 +13,8 @@ sub new {
 }
 
 sub plugins {
-
-  # Modern system with firewalld?
-  if (-x "/usr/bin/firewall-cmd" || -x "/bin/firewall-cmd") {
-    return [
-      "Webmin",    "Nginx",    "Bind",    "Postfix",    "MySQL",
-      "Firewalld", "Procmail", "ProFTPd", "Quotas",     "Shells",
-      "Status",    "Upgrade",  "Usermin", "Virtualmin", "Dovecot",
-      "SASL",      "Etckeeper"
-    ];
-  }
-  else {
-    return [
-      "Webmin",   "Nginx",    "Bind",    "Postfix",    "MySQL",
-      "Firewall", "Procmail", "ProFTPd", "Quotas",     "Shells",
-      "Status",   "Upgrade",  "Usermin", "Virtualmin", "Dovecot",
-      "SASL",     "Etckeeper"
-    ];
-  }
+  my ($self, $stack) = @_;
+  return $stack->list('lemp');
 }
 
 1;

--- a/lib/Virtualmin/Config/MiniLEMP.pm
+++ b/lib/Virtualmin/Config/MiniLEMP.pm
@@ -14,7 +14,7 @@ sub new {
 
 sub plugins {
   my ($self, $stack) = @_;
-  return $stack->list('lemp');
+  return $stack->list('lemp', 'mini');
 }
 
 1;

--- a/lib/Virtualmin/Config/Stack.pm
+++ b/lib/Virtualmin/Config/Stack.pm
@@ -1,0 +1,64 @@
+package Virtualmin::Config::Stack;
+use strict;
+use warnings;
+use 5.010_001;
+
+# A stack for configuring inside plugins
+
+sub new {
+  my ($class, %args) = @_;
+  my $self = {};
+  return bless $self, $class;
+}
+
+# Common modules for all stacks
+sub common_modules {
+    return (
+        "Webmin",      "Bind",      "Postfix",
+        "MySQL",       "Firewall",  "Procmail",
+        "Quotas",      "Shells",    "Status",
+        "Upgrade",     "Usermin",   "Virtualmin",
+        "Dovecot",     "SASL",      "Etckeeper",
+        "Apache"
+    );
+}
+
+# Extra full stack modules
+sub full_modules {
+    return (
+        "ProFTPd",      "AWStats", "ClamAV",
+        "SpamAssassin", "Fail2ban"
+    );
+}
+
+# Replacement logic for modules
+sub replacements {
+    my ($type) = @_;
+
+    # Modern system with Firewalld?
+    my $firewalld =
+        grep { -x "$_/firewall-cmd" } split(/:/, "/usr/bin:/bin:$ENV{PATH}");
+
+    # Define replacements
+    return {
+        "Firewall" => $firewalld ? "Firewalld" : "Firewall",
+        "Fail2ban" => $firewalld ? "Fail2banFirewalld" : "Fail2ban",
+        "Apache"   => $type eq 'lemp' ? "Nginx" : "Apache",
+    };
+}
+
+sub list {
+    my ($self, $type, $full) = @_;
+
+    # Get common and optional full modules
+    my @modules = common_modules();
+    push(@modules, full_modules()) if ($full);
+
+    # Apply replacements
+    my %replacements = %{ replacements($type) };
+    @modules = map { $replacements{$_} // $_ } @modules;
+
+    return \@modules;
+}
+
+1;

--- a/lib/Virtualmin/Config/Stack.pm
+++ b/lib/Virtualmin/Config/Stack.pm
@@ -11,19 +11,31 @@ sub new {
   return bless $self, $class;
 }
 
-# Common modules for all stacks
+# Common modules for all stacks (excluding DNS, mail and extra)
 sub common_modules {
     return (
-        "Webmin",      "Bind",      "Postfix",
-        "MySQL",       "Firewall",  "Procmail",
+        "Webmin",      "MySQL",     "Firewall",
         "Quotas",      "Shells",    "Status",
         "Upgrade",     "Usermin",   "Virtualmin",
-        "Dovecot",     "SASL",      "Etckeeper",
-        "Apache"
+        "Etckeeper",   "Apache"
     );
 }
 
-# Extra full stack modules
+# Modules related to DNS
+sub dns_modules {
+    return (
+        "Bind"
+    );
+}
+
+# Modules related to mail
+sub mail_modules {
+    return (
+        "Postfix", "Dovecot", "SASL", "Procmail"
+    );
+}
+
+# Extra (resourceful) modules
 sub full_modules {
     return (
         "ProFTPd",      "AWStats", "ClamAV",
@@ -48,11 +60,13 @@ sub replacements {
 }
 
 sub list {
-    my ($self, $type, $full) = @_;
+    my ($self, $type, $subtype) = @_;
 
     # Get common and optional full modules
     my @modules = common_modules();
-    push(@modules, full_modules()) if ($full);
+    push(@modules, dns_modules())  if ($subtype ne 'nano');
+    push(@modules, mail_modules()) if ($subtype !~ /\b(?:micro|nano)\b/);
+    push(@modules, full_modules()) if ($subtype eq 'full');
 
     # Apply replacements
     my %replacements = %{ replacements($type) };


### PR DESCRIPTION
This change addresses the issues with packages in different stacks, including one where ProFTPd was configured as part of the minimal stack, which [led to the error](https://forum.virtualmin.com/t/virtualmin-installation-error-on-almalinux-and-rockylinux/131195/8?u=ilia
).

Now it will be much simpler to handle package configurations depending on the stack using this new code design.

And, in my opinion, we should also add a "Micro" stack, without mail, and a "Nano" stack without mail and local DNS.
